### PR TITLE
Verbose and dry-run options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,22 @@ Quickly toss a directory to Amazon S3 from the command line.
 
 ## Usage
 
-    lob some_directory
+    $ lob some_directory
+    some_directory/index.html -> index.html
+    some_directory/stylesheets/application.css -> stylesheets/application.css
 
-Or pass in a bucket name to substitute your $FOG_DIRECTORY env variable:
+Pass in a bucket name to substitute your $FOG_DIRECTORY env variable:
 
-    lob some_directory --bucket some_aws_bucket
+    $ lob some_directory --bucket some_aws_bucket
+
+Set `--dry-run` to just see what files would be uploaded:
+
+    $ log some_directory --dry-run
+
+Set `--no-verbose` to suppress printing filenames while uploading:
+
+    $ log some_directory --no-verbose
+
 
 ## Required Environment Variables
 

--- a/lib/lobber/cli.rb
+++ b/lib/lobber/cli.rb
@@ -14,7 +14,7 @@ module Lobber
         exit 1
       end
 
-      Lobber.upload(directory, options[:bucket])
+      Lobber.upload(directory, options)
 
       say "Successfully uploaded #{directory}", "\033[32m"
     end

--- a/lib/lobber/cli.rb
+++ b/lib/lobber/cli.rb
@@ -5,7 +5,9 @@ module Lobber
     default_task :lob
 
     desc "DIRECTORY", "Upload a directory to Amazon S3"
-    option :bucket
+    method_option :bucket, type: :string
+    method_option :dry_run, default: false, type: :boolean
+    method_option :verbose, default: true, type: :boolean
     def lob(directory = nil)
       return usage unless directory
 

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -8,7 +8,7 @@ module Lobber
     def initialize(directory, options = {})
       @directory = sanitize(directory)
 
-      @bucket_name = options.fetch(:bucket_name, nil)
+      @bucket_name = options.fetch(:bucket, nil)
       @verbose = options.fetch(:verbose, true)
     end
 

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -53,6 +53,12 @@ module Lobber
 
     def create_file file
       key = Pathname.new(file).relative_path_from(Pathname.new(directory)).to_s
+
+      if already_identical?(file, key)
+        log "#{file} identical"
+        return
+      end
+
       log file, key
       return if dry_run
       bucket.files.create(key: key, public: true, body: File.open(file))
@@ -91,6 +97,11 @@ module Lobber
     end
 
     private
+
+    def already_identical?(file, key)
+      remote_file = bucket.files.head(key)
+      remote_file && Digest::MD5.hexdigest(File.read(file)) == remote_file.etag
+    end
 
     def log(*strings)
       puts strings.join(' -> ') if verbose

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -68,7 +68,8 @@ module Lobber
       @s3 ||= Fog::Storage.new(
         provider: :aws,
         aws_access_key_id: aws_access_key,
-        aws_secret_access_key: aws_secret_key
+        aws_secret_access_key: aws_secret_key,
+        path_style: fog_directory.include?(?.)
       )
     end
 

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -48,7 +48,8 @@ module Lobber
     end
 
     def create_file file
-      bucket.files.create(key: file, public: true, body: File.open(file))
+      key = File.basename(file)
+      bucket.files.create(key: key, public: true, body: File.open(file))
     end
 
     def s3

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -3,13 +3,14 @@ require 'rake'
 
 module Lobber
   class Uploader
-    attr_reader :directory, :bucket_name, :verbose
+    attr_reader :directory, :bucket_name, :dry_run, :verbose
 
     def initialize(directory, options = {})
       @directory = sanitize(directory)
 
-      @bucket_name = options.fetch(:bucket, nil)
-      @verbose = options.fetch(:verbose, true)
+      @bucket_name = options.fetch('bucket', nil)
+      @dry_run = options.fetch('dry_run', false)
+      @verbose = options.fetch('verbose', true)
     end
 
     def upload
@@ -46,12 +47,14 @@ module Lobber
     end
 
     def create_directory directory
+      return if dry_run
       bucket.files.create(key: directory, public: true)
     end
 
     def create_file file
       key = Pathname.new(file).relative_path_from(Pathname.new(directory)).to_s
       log file, key
+      return if dry_run
       bucket.files.create(key: key, public: true, body: File.open(file))
     end
 

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -51,7 +51,7 @@ module Lobber
 
     def create_file file
       log file
-      key = File.basename(file)
+      key = Pathname.new(file).relative_path_from(Pathname.new(directory)).to_s
       bucket.files.create(key: key, public: true, body: File.open(file))
     end
 

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -50,8 +50,8 @@ module Lobber
     end
 
     def create_file file
-      log file
       key = Pathname.new(file).relative_path_from(Pathname.new(directory)).to_s
+      log file, key
       bucket.files.create(key: key, public: true, body: File.open(file))
     end
 
@@ -89,8 +89,8 @@ module Lobber
 
     private
 
-    def log(text)
-      puts text if verbose
+    def log(*strings)
+      puts strings.join(' -> ') if verbose
     end
 
     def sanitize(directory_path)

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -3,12 +3,13 @@ require 'rake'
 
 module Lobber
   class Uploader
-    attr_reader :directory, :bucket_name
+    attr_reader :directory, :bucket_name, :verbose
 
     def initialize(directory, options = {})
       @directory = sanitize(directory)
 
-      @bucket_name = options[:bucket_name]
+      @bucket_name = options.fetch(:bucket_name, nil)
+      @verbose = options.fetch(:verbose, true)
     end
 
     def upload
@@ -49,6 +50,7 @@ module Lobber
     end
 
     def create_file file
+      log file
       key = File.basename(file)
       bucket.files.create(key: key, public: true, body: File.open(file))
     end
@@ -86,6 +88,10 @@ module Lobber
     end
 
     private
+
+    def log(text)
+      puts text if verbose
+    end
 
     def sanitize(directory_path)
       if directory_path.match(/\/$/)

--- a/lib/lobber/uploader.rb
+++ b/lib/lobber/uploader.rb
@@ -5,9 +5,10 @@ module Lobber
   class Uploader
     attr_reader :directory, :bucket_name
 
-    def initialize(directory, bucket_name = nil)
-      @bucket_name = bucket_name
+    def initialize(directory, options = {})
       @directory = sanitize(directory)
+
+      @bucket_name = options[:bucket_name]
     end
 
     def upload
@@ -81,7 +82,7 @@ module Lobber
     end
 
     def fog_directory
-      @bucket_name || ENV['FOG_DIRECTORY']
+      bucket_name || ENV['FOG_DIRECTORY']
     end
 
     private

--- a/spec/lib/lobber/cli_spec.rb
+++ b/spec/lib/lobber/cli_spec.rb
@@ -51,7 +51,7 @@ describe Lobber::CLI do
       end
 
       it "uploads" do
-        expect(Lobber).to receive(:upload).with("foo", nil)
+        expect(Lobber).to receive(:upload).with("foo", {})
         cli.lob "foo"
       end
 

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -88,12 +88,34 @@ describe Lobber::Uploader do
   end
 
   describe "#create_file" do
-    it "creates an s3 file" do
+    before do
       allow(File).to receive(:open).and_return 'content'
+    end
+
+    let(:filename) { 'foo.bar' }
+
+    it "creates an s3 file" do
       expect(uploader.bucket.files)
         .to receive(:create)
-        .with(key: 'foo.bar', public: true, body: 'content')
-      uploader.create_file "/home/foo.bar"
+        .with(key: filename, public: true, body: 'content')
+      uploader.create_file filename
+    end
+
+    it "logs each file to the screen" do
+      expect(uploader).to receive(:log).with(filename)
+      uploader.create_file filename
+    end
+
+    context "with a directory outside of the working path" do
+      let(:directory_name) { '/home/' }
+      let(:filename) { '/home/foo/bar.baz' }
+
+      it "strips the directory name from the upload key" do
+        expect(uploader.bucket.files)
+          .to receive(:create)
+          .with(key: 'bar.baz', public: true, body: 'content')
+        uploader.create_file filename
+      end
     end
   end
 

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -87,8 +87,10 @@ describe Lobber::Uploader do
   describe "#create_file" do
     it "creates an s3 file" do
       allow(File).to receive(:open).and_return 'content'
-      expect(uploader.bucket.files).to receive(:create).with(key: 'foo', public: true, body: 'content')
-      uploader.create_file "foo"
+      expect(uploader.bucket.files)
+        .to receive(:create)
+        .with(key: 'foo.bar', public: true, body: 'content')
+      uploader.create_file "/home/foo.bar"
     end
   end
 

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -10,6 +10,7 @@ describe Lobber::Uploader do
     Fog.mock!
     allow(uploader).to receive(:aws_access_key).and_return 'fake key'
     allow(uploader).to receive(:aws_secret_key).and_return 'fake key'
+    allow(uploader).to receive(:verbose).and_return false
     allow(ENV).to receive(:[])
     allow(ENV).to receive(:[]).with('FOG_DIRECTORY').and_return directory_name
   end

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -103,7 +103,7 @@ describe Lobber::Uploader do
     end
 
     it "logs each file to the screen" do
-      expect(uploader).to receive(:log).with(filename)
+      expect(uploader).to receive(:log).with(filename, 'foo.bar')
       uploader.create_file filename
     end
 

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -155,9 +155,21 @@ describe Lobber::Uploader do
       expect(Fog::Storage).to receive(:new).with(
         provider: :aws,
         aws_access_key_id: 'aws_access_key',
-        aws_secret_access_key: 'aws_secret_key'
+        aws_secret_access_key: 'aws_secret_key',
+        path_style: false
       )
       uploader.s3
+    end
+
+    context "with a fog directory that includes a period" do
+      let(:directory_name) { "foo.bar" }
+
+      it "sets path style to true to silence warnings" do
+        expect(Fog::Storage).to receive(:new) do |options|
+          expect(options[:path_style]).to eq(true)
+        end
+        uploader.s3
+      end
     end
   end
 

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -107,6 +107,17 @@ describe Lobber::Uploader do
       uploader.create_file filename
     end
 
+    context "when the local and remote file are identical" do
+      before do
+        allow(uploader).to receive(:already_identical?).and_return(true)
+      end
+
+      it "does not upload the file again" do
+        expect(uploader.bucket.files).to_not receive(:create)
+        uploader.create_file filename
+      end
+    end
+
     context "with --dry-run" do
       let(:options) { { 'dry_run' => true } }
 

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
 describe Lobber::Uploader do
+  subject(:uploader) { Lobber::Uploader.new(directory_name, options) }
+
   let(:directory_name) { 'spec' }
-  let(:uploader) { Lobber::Uploader.new(directory_name) }
+  let(:options) { {} }
 
   before :each do
     Fog.mock!
     allow(uploader).to receive(:aws_access_key).and_return 'fake key'
     allow(uploader).to receive(:aws_secret_key).and_return 'fake key'
-    allow(uploader).to receive(:fog_directory).and_return directory_name
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with('FOG_DIRECTORY').and_return directory_name
   end
 
   after :each do
@@ -156,17 +159,15 @@ describe Lobber::Uploader do
   describe "#fog_directory" do
     context "the uploader is not instantiated with a bucket name parameter" do
       it "returns the value of the FOG_DIRECTORY environment variable" do
-        some_uploader = Lobber::Uploader.new 'foo'
-        allow(ENV).to receive(:[])
-        expect(ENV).to receive(:[]).with 'FOG_DIRECTORY'
-        some_uploader.fog_directory
+        expect(uploader.fog_directory).to eq(directory_name)
       end
     end
 
     context "the uploader is instantiated with a bucket name parameter" do
+      let(:options) { { bucket_name: 'bar' } }
+
       it "returns the value of the bucket name it was passed on instantiation" do
-        some_uploader = Lobber::Uploader.new 'foo', 'bar'
-        expect(some_uploader.fog_directory).to eq 'bar'
+        expect(uploader.fog_directory).to eq('bar')
       end
     end
   end

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -93,12 +93,12 @@ describe Lobber::Uploader do
       allow(File).to receive(:open).and_return 'content'
     end
 
-    let(:filename) { 'foo.bar' }
+    let(:filename) { File.join(directory_name, 'foo.bar') }
 
     it "creates an s3 file" do
       expect(uploader.bucket.files)
         .to receive(:create)
-        .with(key: filename, public: true, body: 'content')
+        .with(key: 'foo.bar', public: true, body: 'content')
       uploader.create_file filename
     end
 
@@ -114,7 +114,7 @@ describe Lobber::Uploader do
       it "strips the directory name from the upload key" do
         expect(uploader.bucket.files)
           .to receive(:create)
-          .with(key: 'bar.baz', public: true, body: 'content')
+          .with(key: 'foo/bar.baz', public: true, body: 'content')
         uploader.create_file filename
       end
     end

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -107,6 +107,20 @@ describe Lobber::Uploader do
       uploader.create_file filename
     end
 
+    context "with --dry-run" do
+      let(:options) { { 'dry_run' => true } }
+
+      it "does not create directories" do
+        expect(uploader.bucket.files).to_not receive(:create)
+        uploader.create_directory directory_name
+      end
+
+      it "does not upload files" do
+        expect(uploader.bucket.files).to_not receive(:create)
+        uploader.create_file filename
+      end
+    end
+
     context "with a directory outside of the working path" do
       let(:directory_name) { '/home/' }
       let(:filename) { '/home/foo/bar.baz' }
@@ -187,7 +201,7 @@ describe Lobber::Uploader do
     end
 
     context "the uploader is instantiated with a bucket name parameter" do
-      let(:options) { { bucket: 'bar' } }
+      let(:options) { { 'bucket' => 'bar' } }
 
       it "returns the value of the bucket name it was passed on instantiation" do
         expect(uploader.fog_directory).to eq('bar')

--- a/spec/lib/lobber/uploader_spec.rb
+++ b/spec/lib/lobber/uploader_spec.rb
@@ -187,7 +187,7 @@ describe Lobber::Uploader do
     end
 
     context "the uploader is instantiated with a bucket name parameter" do
-      let(:options) { { bucket_name: 'bar' } }
+      let(:options) { { bucket: 'bar' } }
 
       it "returns the value of the bucket name it was passed on instantiation" do
         expect(uploader.fog_directory).to eq('bar')


### PR DESCRIPTION
- Log each file uploaded to the screen, disable with `--no-verbose`
- Fix an issue where lobbing outside of the current path would create an invalid S3 file key
- Add `--dry-run` mode for testing a lob
